### PR TITLE
Redesign portfolio with cinematic warm-dark theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,188 @@
-import Navbar from './components/Navbar'
-import Hero from './components/Hero'
-import Projects from './components/Projects'
-import StatisticalDataAnalysis from './components/StatisticalDataAnalysis'
-import MLOps from './components/MLOps'
-import Education from './components/Education'
-import Contact from './components/Contact'
-import Footer from './components/Footer'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import Home from './pages/Home'
+import Work from './pages/Work'
+import Academic from './pages/Academic'
+import About from './pages/About'
 
-function App() {
+const PAGES = {
+  '/': Home,
+  '/work': Work,
+  '/academic': Academic,
+  '/about': About,
+}
+
+const ORDER = { '/': 0, '/work': 1, '/academic': 2, '/about': 3 }
+
+const NAV = [
+  { path: '/', label: 'Home' },
+  { path: '/work', label: 'Work' },
+  { path: '/academic', label: 'Academic' },
+  { path: '/about', label: 'About' },
+]
+
+function getPath() {
+  const p = window.location.pathname
+  return PAGES[p] ? p : '/'
+}
+
+export default function App() {
+  const [route, setRoute] = useState(getPath)
+  const [anim, setAnim] = useState('')
+  const prevRef = useRef(route)
+  const timerRef = useRef(null)
+
+  const doNavigate = useCallback((next, push = true) => {
+    const cur = prevRef.current
+    if (next === cur) return
+    const dir = (ORDER[next] ?? 0) >= (ORDER[cur] ?? 0) ? 'forward' : 'back'
+
+    clearTimeout(timerRef.current)
+    setAnim(dir === 'forward' ? 'route-exit-forward' : 'route-exit-back')
+
+    timerRef.current = setTimeout(() => {
+      if (push) window.history.pushState({}, '', next)
+      prevRef.current = next
+      setRoute(next)
+      setAnim(dir === 'forward' ? 'route-enter-forward' : 'route-enter-back')
+      timerRef.current = setTimeout(() => setAnim(''), 360)
+    }, 210)
+  }, [])
+
+  useEffect(() => {
+    const onPop = () => {
+      const next = getPath()
+      doNavigate(next, false)
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [doNavigate])
+
+  useEffect(() => () => clearTimeout(timerRef.current), [])
+
+  const Page = PAGES[route] || Home
+
   return (
-    <div className="min-h-screen bg-primary text-white">
-      <Navbar />
-      <Hero />
-      <Projects />
-      <StatisticalDataAnalysis />
-      <MLOps />
-      <Education />
-      <Contact />
-      <Footer />
+    <div style={{ backgroundColor: 'var(--bg-0)', color: 'var(--text-0)', minHeight: '100vh' }}>
+
+      {/* ── Desktop top nav ── */}
+      <header style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+        borderBottom: '1px solid var(--line-0)',
+        backgroundColor: 'rgba(18,16,16,0.82)',
+        backdropFilter: 'blur(14px)',
+        WebkitBackdropFilter: 'blur(14px)',
+      }}>
+        <nav style={{
+          maxWidth: '1100px',
+          margin: '0 auto',
+          padding: '0 1.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          height: '58px',
+        }}>
+          {/* Wordmark */}
+          <button
+            onClick={() => doNavigate('/')}
+            style={{
+              fontWeight: 700,
+              fontSize: '1.05rem',
+              letterSpacing: '-0.03em',
+              color: 'var(--text-0)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+              fontFamily: 'inherit',
+            }}
+          >
+            Nafees
+          </button>
+
+          {/* Desktop links */}
+          <div className="desktop-only" style={{ display: 'flex', gap: '0.125rem' }}>
+            {NAV.map(({ path, label }) => {
+              const active = route === path
+              return (
+                <button
+                  key={path}
+                  onClick={() => doNavigate(path)}
+                  style={{
+                    padding: '0.35rem 0.9rem',
+                    fontSize: '0.875rem',
+                    fontWeight: active ? 600 : 400,
+                    color: active ? 'var(--text-0)' : 'var(--text-2)',
+                    background: 'none',
+                    border: 'none',
+                    borderBottom: active
+                      ? '2px solid var(--accent-red)'
+                      : '2px solid transparent',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    transition: 'color 0.15s, border-color 0.15s',
+                    marginBottom: '-1px',
+                  }}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        </nav>
+      </header>
+
+      {/* ── Page content ── */}
+      <main className={anim} style={{ minHeight: 'calc(100vh - 58px)' }}>
+        <Page navigate={doNavigate} />
+      </main>
+
+      {/* ── Mobile bottom pill nav ── */}
+      <nav
+        className="mobile-only"
+        style={{
+          position: 'fixed',
+          bottom: '1.25rem',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 50,
+          backgroundColor: 'var(--bg-1)',
+          border: '1px solid var(--line-1)',
+          borderRadius: '9999px',
+          padding: '0.3rem',
+          display: 'flex',
+          gap: '0.1rem',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.45)',
+          backdropFilter: 'blur(14px)',
+          WebkitBackdropFilter: 'blur(14px)',
+        }}
+      >
+        {NAV.map(({ path, label }) => {
+          const active = route === path
+          return (
+            <button
+              key={path}
+              onClick={() => doNavigate(path)}
+              style={{
+                padding: '0.45rem 0.9rem',
+                fontSize: '0.78rem',
+                fontWeight: active ? 600 : 400,
+                color: active ? 'var(--text-0)' : 'var(--text-2)',
+                backgroundColor: active ? 'var(--bg-2)' : 'transparent',
+                border: 'none',
+                borderRadius: '9999px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                transition: 'background-color 0.15s, color 0.15s',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </nav>
     </div>
   )
 }
-
-export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,72 +1,153 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  font-family: 'Poppins', 'Inter', 'Montserrat', sans-serif;
+  --bg-0: #121010;
+  --bg-1: #1a1515;
+  --bg-2: #231d1c;
+  --text-0: #f3eee7;
+  --text-1: #c9bfb2;
+  --text-2: #93897b;
+  --line-0: #2d2625;
+  --line-1: #413736;
+  --accent-red: #8c3836;
+
+  font-family: 'Inter', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #121212;
-
+  color: var(--text-0);
+  background-color: var(--bg-0);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-body {
+*, *::before, *::after {
+  box-sizing: border-box;
   margin: 0;
+  padding: 0;
+}
+
+body {
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--bg-0);
 }
 
-@layer components {
-  .gradient-text {
-    @apply bg-gradient-to-r from-accent-blue via-accent-lightBlue to-accent-darkBlue bg-clip-text text-transparent;
-  }
-  
-  .gradient-border {
-    @apply relative before:absolute before:inset-0 before:p-[2px] before:bg-gradient-to-r before:from-accent-blue before:via-accent-lightBlue before:to-accent-darkBlue before:rounded-lg before:-z-10;
-  }
-  
-  .card {
-    @apply bg-secondary rounded-lg p-6 shadow-lg transition-all duration-300 hover:shadow-xl hover:translate-y-[-5px];
-  }
-  
-  .section-title {
-    @apply text-4xl font-bold mb-8 text-center;
-  }
-  
-  .container {
-    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
-  }
+/* ── Route transition keyframes ── */
+@keyframes enterFromRight {
+  from { opacity: 0; transform: translateX(36px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes enterFromLeft {
+  from { opacity: 0; transform: translateX(-36px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes exitToLeft {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(-36px); }
+}
+@keyframes exitToRight {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(36px); }
 }
 
-html {
-  scroll-behavior: smooth;
+.route-enter-forward {
+  animation: enterFromRight 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
-button:hover {
-  border-color: #646cff;
+.route-exit-forward {
+  animation: exitToLeft 0.2s ease-in both;
+  pointer-events: none;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.route-enter-back {
+  animation: enterFromLeft 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.route-exit-back {
+  animation: exitToRight 0.2s ease-in both;
+  pointer-events: none;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* ── Scrollbar ── */
+::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar-track { background: var(--bg-0); }
+::-webkit-scrollbar-thumb { background: var(--line-1); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-2); }
+
+/* ── Visibility helpers ── */
+@media (max-width: 768px) {
+  .desktop-only { display: none !important; }
+}
+@media (min-width: 769px) {
+  .mobile-only { display: none !important; }
+}
+
+/* ── Shared components ── */
+.cinema-card {
+  background-color: var(--bg-1);
+  border: 1px solid var(--line-0);
+  border-radius: 2rem;
+  box-shadow: 0 18px 60px rgba(0,0,0,0.28);
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.28rem 0.7rem;
+  background-color: var(--bg-2);
+  border: 1px solid var(--line-1);
+  border-radius: 9999px;
+  font-size: 0.76rem;
+  color: var(--text-2);
+  font-weight: 500;
+  letter-spacing: 0.015em;
+}
+
+.btn-primary {
+  padding: 0.7rem 1.6rem;
+  background-color: var(--accent-red);
+  color: var(--text-0);
+  border: none;
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 0.15s;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.btn-primary:hover { opacity: 0.82; }
+
+.btn-ghost {
+  padding: 0.7rem 1.6rem;
+  background-color: transparent;
+  color: var(--text-1);
+  border: 1px solid var(--line-1);
+  border-radius: 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.btn-ghost:hover {
+  border-color: var(--text-2);
+  color: var(--text-0);
+}
+
+/* ── Focus ring ── */
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent-red);
+  outline-offset: 3px;
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,211 @@
+const HIGHLIGHTS = [
+  {
+    title: 'Data Systems',
+    description:
+      'Designing pipelines and dashboards that turn raw data into reliable signals — from ingestion to visualisation.',
+    icon: '◈',
+  },
+  {
+    title: 'Machine Learning',
+    description:
+      'Applying supervised and unsupervised methods to real-world problems: recommender systems, NLP, clustering.',
+    icon: '◉',
+  },
+  {
+    title: 'Software Engineering',
+    description:
+      'Writing backend APIs, full-stack web apps, and tooling that ships — with clean code and pragmatic architecture.',
+    icon: '◎',
+  },
+]
+
+const CONTACT_LINKS = [
+  {
+    label: 'GitHub',
+    href: 'https://github.com/blue-jays',
+    desc: '@blue-jays',
+  },
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/in/md-nazmun-hasan-nafees/',
+    desc: 'md-nazmun-hasan-nafees',
+  },
+  {
+    label: 'Email',
+    href: 'mailto:nafeeshasan365@gmail.com',
+    desc: 'nafeeshasan365@gmail.com',
+  },
+  {
+    label: 'Resume',
+    href: '/resume.pdf',
+    desc: 'Download PDF',
+    newTab: true,
+  },
+]
+
+export default function About() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '4rem 1.5rem 7rem' }}>
+
+      {/* Page header */}
+      <div style={{ marginBottom: '3.5rem', maxWidth: '680px' }}>
+        <p style={{
+          fontSize: '0.68rem',
+          letterSpacing: '0.2em',
+          color: 'var(--text-2)',
+          textTransform: 'uppercase',
+          fontWeight: 500,
+          marginBottom: '0.75rem',
+        }}>
+          About
+        </p>
+        <h1 style={{
+          fontSize: 'clamp(2rem, 5vw, 3.25rem)',
+          fontWeight: 800,
+          letterSpacing: '-0.04em',
+          color: 'var(--text-0)',
+          marginBottom: '1.75rem',
+        }}>
+          Md Nazmun Hasan Nafees
+        </h1>
+
+        <p style={{
+          fontSize: '1.0rem',
+          color: 'var(--text-1)',
+          lineHeight: 1.8,
+          marginBottom: '1.25rem',
+        }}>
+          I&apos;m a Software Engineering student at Seneca Polytechnic in Toronto, focused on building systems that extract insight from data. I enjoy working across the full stack — from designing machine learning pipelines to shipping clean web interfaces.
+        </p>
+        <p style={{
+          fontSize: '1.0rem',
+          color: 'var(--text-2)',
+          lineHeight: 1.8,
+          marginBottom: '1.25rem',
+        }}>
+          Currently working as a Data Analyst at Montecassino Retirement Residence, where I automate reporting pipelines and build dashboards that support care decisions. I&apos;m actively seeking software engineering or data internship opportunities for 2025/26.
+        </p>
+        <p style={{
+          fontSize: '1.0rem',
+          color: 'var(--text-2)',
+          lineHeight: 1.8,
+        }}>
+          Outside of work and school, I contribute to open-source projects, build browser tools, and explore the intersection of language models and information integrity.
+        </p>
+      </div>
+
+      {/* Highlight cards */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))',
+        gap: '1.25rem',
+        marginBottom: '3.5rem',
+      }}>
+        {HIGHLIGHTS.map(({ title, description, icon }) => (
+          <div
+            key={title}
+            className="cinema-card"
+            style={{ padding: '1.75rem' }}
+          >
+            <div style={{
+              width: '2.5rem',
+              height: '2.5rem',
+              borderRadius: '0.75rem',
+              backgroundColor: 'var(--bg-2)',
+              border: '1px solid var(--line-1)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '1.1rem',
+              color: 'var(--accent-red)',
+              marginBottom: '1.1rem',
+            }}>
+              {icon}
+            </div>
+            <h3 style={{
+              fontSize: '1rem',
+              fontWeight: 700,
+              color: 'var(--text-0)',
+              letterSpacing: '-0.02em',
+              marginBottom: '0.6rem',
+            }}>
+              {title}
+            </h3>
+            <p style={{
+              fontSize: '0.855rem',
+              color: 'var(--text-2)',
+              lineHeight: 1.7,
+            }}>
+              {description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Contact section */}
+      <div>
+        <p style={{
+          fontSize: '0.68rem',
+          letterSpacing: '0.2em',
+          color: 'var(--text-2)',
+          textTransform: 'uppercase',
+          fontWeight: 500,
+          marginBottom: '1.25rem',
+        }}>
+          Contact
+        </p>
+
+        <div className="cinema-card" style={{ padding: '0' }}>
+          {CONTACT_LINKS.map(({ label, href, desc, newTab }, i) => (
+            <a
+              key={label}
+              href={href}
+              target={newTab ? '_blank' : undefined}
+              rel={newTab ? 'noopener noreferrer' : undefined}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: '1rem',
+                padding: '1.1rem 1.75rem',
+                borderBottom: i < CONTACT_LINKS.length - 1
+                  ? '1px solid var(--line-0)'
+                  : 'none',
+                textDecoration: 'none',
+                transition: 'background-color 0.15s',
+                borderRadius: i === 0
+                  ? '2rem 2rem 0 0'
+                  : i === CONTACT_LINKS.length - 1
+                    ? '0 0 2rem 2rem'
+                    : '0',
+              }}
+              onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-2)' }}
+              onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent' }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                <span style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  backgroundColor: 'var(--accent-red)',
+                  flexShrink: 0,
+                }} />
+                <span style={{
+                  fontSize: '0.9rem',
+                  fontWeight: 600,
+                  color: 'var(--text-0)',
+                }}>
+                  {label}
+                </span>
+              </div>
+              <span style={{ fontSize: '0.82rem', color: 'var(--text-2)' }}>
+                {desc} →
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/src/pages/Academic.jsx
+++ b/src/pages/Academic.jsx
@@ -1,0 +1,208 @@
+const SKILLS = {
+  'Languages': ['Python', 'JavaScript', 'TypeScript', 'SQL', 'R', 'Java', 'C++'],
+  'Data & ML': ['Pandas', 'NumPy', 'Scikit-learn', 'PyTorch', 'TensorFlow', 'Matplotlib', 'Seaborn'],
+  'Backend & APIs': ['FastAPI', 'Flask', 'Node.js', 'Express', 'REST APIs', 'PostgreSQL', 'MongoDB'],
+  'DevOps & Cloud': ['Docker', 'Git', 'GitHub Actions', 'Heroku', 'Linux', 'CI/CD'],
+  'Frontend': ['React', 'Vite', 'TailwindCSS', 'HTML', 'CSS'],
+}
+
+function SectionLabel({ children }) {
+  return (
+    <p style={{
+      fontSize: '0.68rem',
+      letterSpacing: '0.2em',
+      color: 'var(--text-2)',
+      textTransform: 'uppercase',
+      fontWeight: 500,
+      marginBottom: '0.75rem',
+    }}>
+      {children}
+    </p>
+  )
+}
+
+function Card({ children, style = {} }) {
+  return (
+    <div className="cinema-card" style={{ padding: '2rem', ...style }}>
+      {children}
+    </div>
+  )
+}
+
+function MetaRow({ label, value, last = false }) {
+  return (
+    <div style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      gap: '1.25rem',
+      padding: '0.65rem 0',
+      borderBottom: last ? 'none' : '1px solid var(--line-0)',
+    }}>
+      <span style={{ fontSize: '0.78rem', color: 'var(--text-2)', fontWeight: 500, flexShrink: 0 }}>
+        {label}
+      </span>
+      <span style={{ fontSize: '0.855rem', color: 'var(--text-1)', textAlign: 'right' }}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export default function Academic() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '4rem 1.5rem 7rem' }}>
+
+      {/* Page header */}
+      <div style={{ marginBottom: '3rem' }}>
+        <SectionLabel>Background</SectionLabel>
+        <h1 style={{
+          fontSize: 'clamp(2rem, 5vw, 3.25rem)',
+          fontWeight: 800,
+          letterSpacing: '-0.04em',
+          color: 'var(--text-0)',
+        }}>
+          Academic & Experience
+        </h1>
+      </div>
+
+      {/* Top row: Education + Experience */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
+        gap: '1.5rem',
+        marginBottom: '1.5rem',
+      }}>
+
+        {/* Education */}
+        <Card>
+          <SectionLabel>Education</SectionLabel>
+
+          {/* Institution header */}
+          <div style={{ marginBottom: '1.5rem' }}>
+            <h2 style={{
+              fontSize: '1.2rem',
+              fontWeight: 700,
+              color: 'var(--text-0)',
+              letterSpacing: '-0.02em',
+              marginBottom: '0.25rem',
+            }}>
+              Seneca Polytechnic
+            </h2>
+            <p style={{ fontSize: '0.875rem', color: 'var(--text-2)' }}>
+              Software Engineering Technology — Advanced Diploma
+            </p>
+          </div>
+
+          <MetaRow label="Status"    value="In Progress" />
+          <MetaRow label="Location"  value="Toronto, Ontario" />
+          <MetaRow label="GPA"       value="Dean's List" />
+          <MetaRow label="Grad"      value="April 2027" last />
+
+          {/* Focus areas */}
+          <div style={{ marginTop: '1.5rem' }}>
+            <p style={{ fontSize: '0.72rem', color: 'var(--text-2)', letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 500, marginBottom: '0.75rem' }}>
+              Focus Areas
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+              {['Data Engineering', 'Machine Learning', 'Backend Systems', 'Software Architecture'].map(t => (
+                <span key={t} className="tag">{t}</span>
+              ))}
+            </div>
+          </div>
+        </Card>
+
+        {/* Experience */}
+        <Card>
+          <SectionLabel>Experience</SectionLabel>
+
+          <div style={{ marginBottom: '1.5rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.75rem', marginBottom: '0.25rem' }}>
+              <h2 style={{
+                fontSize: '1.2rem',
+                fontWeight: 700,
+                color: 'var(--text-0)',
+                letterSpacing: '-0.02em',
+              }}>
+                Montecassino Retirement Residence
+              </h2>
+            </div>
+            <p style={{ fontSize: '0.875rem', color: 'var(--text-2)' }}>
+              Data Analyst
+            </p>
+          </div>
+
+          <MetaRow label="Period"    value="Apr 2023 – Present" />
+          <MetaRow label="Type"      value="Part-time / Co-op" />
+          <MetaRow label="Location"  value="Toronto, Ontario" last />
+
+          {/* Responsibilities */}
+          <div style={{ marginTop: '1.5rem' }}>
+            <p style={{ fontSize: '0.72rem', color: 'var(--text-2)', letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 500, marginBottom: '0.875rem' }}>
+              Responsibilities
+            </p>
+            <ul style={{ listStyle: 'none', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {[
+                'Built and maintained Excel/Python dashboards for resident care metrics',
+                'Automated weekly reporting pipelines, reducing manual work by 60%',
+                'Analysed occupancy and staffing data to support operational decisions',
+                'Collaborated with management to design data collection procedures',
+              ].map((item, i) => (
+                <li key={i} style={{ display: 'flex', gap: '0.625rem', alignItems: 'flex-start' }}>
+                  <span style={{
+                    width: 5, height: 5,
+                    borderRadius: '50%',
+                    backgroundColor: 'var(--accent-red)',
+                    flexShrink: 0,
+                    marginTop: '0.45rem',
+                  }} />
+                  <span style={{ fontSize: '0.845rem', color: 'var(--text-2)', lineHeight: 1.65 }}>
+                    {item}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
+
+      </div>
+
+      {/* Skills */}
+      <Card>
+        <SectionLabel>Skills</SectionLabel>
+        <h2 style={{
+          fontSize: '1.15rem',
+          fontWeight: 700,
+          color: 'var(--text-0)',
+          letterSpacing: '-0.02em',
+          marginBottom: '1.75rem',
+        }}>
+          Technical Stack
+        </h2>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+          {Object.entries(SKILLS).map(([category, items]) => (
+            <div key={category}>
+              <p style={{
+                fontSize: '0.72rem',
+                color: 'var(--text-2)',
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                fontWeight: 500,
+                marginBottom: '0.6rem',
+              }}>
+                {category}
+              </p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                {items.map(skill => (
+                  <span key={skill} className="tag">{skill}</span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+    </div>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,208 @@
+const PROFILE_ROWS = [
+  { label: 'Role',        value: 'Software Engineering Student' },
+  { label: 'Location',    value: 'Toronto, Ontario' },
+  { label: 'Focus',       value: 'Data Engineering · ML · Backend' },
+  { label: 'Currently',   value: 'Seeking 2025/26 internships' },
+  { label: 'Graduating',  value: 'April 2027' },
+]
+
+const METADATA = ['Toronto', 'Seneca Polytechnic', 'Open to internships']
+
+export default function Home({ navigate }) {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '5rem 1.5rem 7rem' }}>
+
+      {/* Two-column grid */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 420px), 1fr))',
+        gap: '4rem',
+        alignItems: 'start',
+      }}>
+
+        {/* ── Left: Cinematic intro ── */}
+        <div>
+          <p style={{
+            fontSize: '0.68rem',
+            letterSpacing: '0.2em',
+            color: 'var(--text-2)',
+            textTransform: 'uppercase',
+            fontWeight: 500,
+            marginBottom: '1.75rem',
+          }}>
+            Portfolio — 2025
+          </p>
+
+          <div style={{ marginBottom: '1.75rem', lineHeight: 0.95 }}>
+            <h1 style={{
+              fontSize: 'clamp(3.8rem, 10vw, 7.5rem)',
+              fontWeight: 800,
+              letterSpacing: '-0.045em',
+              color: 'var(--text-0)',
+              display: 'block',
+            }}>
+              Nafees
+            </h1>
+            <h1 style={{
+              fontSize: 'clamp(3.8rem, 10vw, 7.5rem)',
+              fontWeight: 800,
+              letterSpacing: '-0.045em',
+              color: 'var(--text-2)',
+              display: 'block',
+            }}>
+              / Hasan
+            </h1>
+          </div>
+
+          <p style={{
+            fontSize: '1.05rem',
+            color: 'var(--text-1)',
+            maxWidth: '460px',
+            lineHeight: 1.75,
+            marginBottom: '2.25rem',
+          }}>
+            Building intelligent systems that make data meaningful — from pipeline to product.
+          </p>
+
+          {/* Metadata strip */}
+          <div style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.5rem 1.5rem',
+            marginBottom: '2.75rem',
+          }}>
+            {METADATA.map(item => (
+              <span key={item} style={{
+                fontSize: '0.82rem',
+                color: 'var(--text-2)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.45rem',
+              }}>
+                <span style={{
+                  width: 5,
+                  height: 5,
+                  borderRadius: '50%',
+                  backgroundColor: 'var(--accent-red)',
+                  display: 'inline-block',
+                  flexShrink: 0,
+                }} />
+                {item}
+              </span>
+            ))}
+          </div>
+
+          {/* CTAs */}
+          <div style={{ display: 'flex', gap: '0.875rem', flexWrap: 'wrap' }}>
+            <button
+              onClick={() => navigate('/work')}
+              className="btn-primary"
+            >
+              View my work
+            </button>
+            <a
+              href="/resume.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-ghost"
+            >
+              Resume →
+            </a>
+          </div>
+        </div>
+
+        {/* ── Right: Profile card ── */}
+        <div className="cinema-card" style={{ padding: '2rem' }}>
+          <p style={{
+            fontSize: '0.68rem',
+            letterSpacing: '0.18em',
+            color: 'var(--text-2)',
+            textTransform: 'uppercase',
+            fontWeight: 500,
+            marginBottom: '1.5rem',
+          }}>
+            Profile
+          </p>
+
+          {PROFILE_ROWS.map(({ label, value }, i) => (
+            <div
+              key={label}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                gap: '1.25rem',
+                padding: '0.7rem 0',
+                borderBottom: i < PROFILE_ROWS.length - 1
+                  ? '1px solid var(--line-0)'
+                  : 'none',
+              }}
+            >
+              <span style={{
+                fontSize: '0.78rem',
+                color: 'var(--text-2)',
+                fontWeight: 500,
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}>
+                {label}
+              </span>
+              <span style={{
+                fontSize: '0.855rem',
+                color: 'var(--text-1)',
+                textAlign: 'right',
+              }}>
+                {value}
+              </span>
+            </div>
+          ))}
+
+          {/* Social links */}
+          <div style={{
+            display: 'flex',
+            gap: '0.625rem',
+            marginTop: '1.75rem',
+          }}>
+            {[
+              { label: 'GitHub', href: 'https://github.com/blue-jays' },
+              { label: 'LinkedIn', href: 'https://www.linkedin.com/in/md-nazmun-hasan-nafees/' },
+            ].map(({ label, href }) => (
+              <a
+                key={label}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: '0.6rem 0.875rem',
+                  backgroundColor: 'var(--bg-2)',
+                  border: '1px solid var(--line-1)',
+                  borderRadius: '0.75rem',
+                  color: 'var(--text-1)',
+                  textDecoration: 'none',
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  transition: 'border-color 0.15s, color 0.15s',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.borderColor = 'var(--text-2)'
+                  e.currentTarget.style.color = 'var(--text-0)'
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.borderColor = 'var(--line-1)'
+                  e.currentTarget.style.color = 'var(--text-1)'
+                }}
+              >
+                {label}
+              </a>
+            ))}
+          </div>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Work.jsx
+++ b/src/pages/Work.jsx
@@ -1,0 +1,215 @@
+const PROJECTS = [
+  {
+    id: 'news-bias',
+    title: 'News Bias Analyzer',
+    subtitle: 'NLP · Chrome Extension · Python',
+    description:
+      'A Chrome extension + Python backend that scores the political bias and sentiment of any news article in real time. Uses fine-tuned transformer models to surface left/centre/right lean with confidence scores, helping readers identify media framing.',
+    tags: ['Python', 'NLP', 'Transformers', 'Chrome Extension', 'FastAPI'],
+    gradient: 'linear-gradient(135deg, #1e1010 0%, #2a1010 40%, #1a1018 100%)',
+    accentColor: '#7a2c2a',
+    github: 'https://github.com/blue-jays/News_Bias_Check_Companion',
+    demo: null,
+    status: 'Open Source',
+  },
+  {
+    id: 'game-rec',
+    title: 'Game Recommender System',
+    subtitle: 'ML · Collaborative Filtering · Heroku',
+    description:
+      'Content + collaborative-filtering recommender that suggests video games based on user preferences and play history. Deployed as a full-stack web app on Heroku with a clean search interface.',
+    tags: ['Python', 'Scikit-learn', 'Pandas', 'Flask', 'Heroku'],
+    gradient: 'linear-gradient(135deg, #101a18 0%, #0e1f1a 50%, #121018 100%)',
+    accentColor: '#1f4f40',
+    github: null,
+    demo: 'https://game-engine-753abe0961a7.herokuapp.com',
+    status: 'Live Demo',
+  },
+  {
+    id: 'customer-seg',
+    title: 'Customer Segmentation — Banking',
+    subtitle: 'Unsupervised ML · EDA · Business Intelligence',
+    description:
+      'K-Means and hierarchical clustering pipeline applied to a retail-banking dataset to discover actionable customer segments. Includes full EDA, dimensionality reduction with PCA, and a Matplotlib dashboard of segment profiles.',
+    tags: ['Python', 'K-Means', 'PCA', 'Matplotlib', 'Pandas'],
+    gradient: 'linear-gradient(135deg, #1a1508 0%, #221c0a 50%, #181210 100%)',
+    accentColor: '#4a3a10',
+    github: null,
+    demo: null,
+    status: 'Case Study',
+  },
+]
+
+function ProjectCard({ project, lead = false }) {
+  const { title, subtitle, description, tags, gradient, accentColor, github, demo, status } = project
+
+  return (
+    <div
+      className="cinema-card"
+      style={{
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+      }}
+    >
+      {/* Gradient banner */}
+      <div style={{
+        background: gradient,
+        height: lead ? '200px' : '140px',
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'flex-end',
+        padding: '1.25rem 1.5rem',
+        borderBottom: '1px solid var(--line-0)',
+      }}>
+        {/* Status badge */}
+        <span style={{
+          position: 'absolute',
+          top: '1rem',
+          right: '1rem',
+          padding: '0.25rem 0.6rem',
+          backgroundColor: 'rgba(0,0,0,0.55)',
+          border: `1px solid ${accentColor}`,
+          borderRadius: '9999px',
+          fontSize: '0.68rem',
+          color: 'var(--text-2)',
+          fontWeight: 500,
+          letterSpacing: '0.05em',
+        }}>
+          {status}
+        </span>
+
+        {/* Decorative grid dots */}
+        <div style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundImage: `radial-gradient(circle, ${accentColor}30 1px, transparent 1px)`,
+          backgroundSize: '28px 28px',
+          opacity: 0.5,
+        }} />
+
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          <p style={{
+            fontSize: '0.68rem',
+            letterSpacing: '0.14em',
+            color: 'var(--text-2)',
+            textTransform: 'uppercase',
+            fontWeight: 500,
+          }}>
+            {subtitle}
+          </p>
+        </div>
+      </div>
+
+      {/* Card body */}
+      <div style={{ padding: '1.5rem', display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <h2 style={{
+          fontSize: lead ? '1.4rem' : '1.1rem',
+          fontWeight: 700,
+          color: 'var(--text-0)',
+          letterSpacing: '-0.02em',
+          marginBottom: '0.625rem',
+        }}>
+          {title}
+        </h2>
+
+        <p style={{
+          fontSize: '0.875rem',
+          color: 'var(--text-2)',
+          lineHeight: 1.7,
+          marginBottom: '1.25rem',
+          flex: 1,
+        }}>
+          {description}
+        </p>
+
+        {/* Tags */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.375rem', marginBottom: '1.25rem' }}>
+          {tags.map(t => <span key={t} className="tag">{t}</span>)}
+        </div>
+
+        {/* Links */}
+        <div style={{ display: 'flex', gap: '0.625rem', flexWrap: 'wrap' }}>
+          {github && (
+            <a
+              href={github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-ghost"
+              style={{ fontSize: '0.8rem', padding: '0.45rem 1rem' }}
+            >
+              GitHub →
+            </a>
+          )}
+          {demo && (
+            <a
+              href={demo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary"
+              style={{ fontSize: '0.8rem', padding: '0.45rem 1rem' }}
+            >
+              Live Demo →
+            </a>
+          )}
+          {!github && !demo && (
+            <span style={{ fontSize: '0.78rem', color: 'var(--text-2)', alignSelf: 'center' }}>
+              Private / Academic
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function Work() {
+  const [lead, ...rest] = PROJECTS
+
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '4rem 1.5rem 7rem' }}>
+
+      {/* Header */}
+      <div style={{ marginBottom: '3rem' }}>
+        <p style={{
+          fontSize: '0.68rem',
+          letterSpacing: '0.2em',
+          color: 'var(--text-2)',
+          textTransform: 'uppercase',
+          fontWeight: 500,
+          marginBottom: '0.75rem',
+        }}>
+          Selected work
+        </p>
+        <h1 style={{
+          fontSize: 'clamp(2rem, 5vw, 3.25rem)',
+          fontWeight: 800,
+          letterSpacing: '-0.04em',
+          color: 'var(--text-0)',
+          marginBottom: '0.875rem',
+        }}>
+          Projects
+        </h1>
+        <p style={{ fontSize: '0.95rem', color: 'var(--text-2)', maxWidth: '520px', lineHeight: 1.7 }}>
+          A selection of data engineering, machine learning, and software projects — from research prototypes to deployed products.
+        </p>
+      </div>
+
+      {/* Lead project (full width) */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <ProjectCard project={lead} lead />
+      </div>
+
+      {/* Paired row */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 340px), 1fr))',
+        gap: '1.5rem',
+      }}>
+        {rest.map(p => <ProjectCard key={p.id} project={p} />)}
+      </div>
+
+    </div>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,41 +6,28 @@ module.exports = {
   ],
   theme: {
     extend: {
-      colors: {
-        primary: "#121212",
-        secondary: "#1e1e1e",
-        accent: {
-          blue: "#2196F3",
-          lightBlue: "#64B5F6",
-          darkBlue: "#0D47A1"
-        }
-      },
       fontFamily: {
-        sans: ['Poppins', 'Inter', 'Montserrat', 'sans-serif'],
+        sans: ['Inter', 'sans-serif'],
       },
-      animation: {
-        fadeIn: 'fadeIn 1s ease-in-out',
-        fadeOut: 'fadeOut 1s ease-in-out',
-        blink: 'blink 1s step-end infinite',
+      colors: {
+        'bg-0': '#121010',
+        'bg-1': '#1a1515',
+        'bg-2': '#231d1c',
+        'text-0': '#f3eee7',
+        'text-1': '#c9bfb2',
+        'text-2': '#93897b',
+        'line-0': '#2d2625',
+        'line-1': '#413736',
+        'accent-red': '#8c3836',
       },
-      keyframes: {
-        fadeIn: {
-          '0%': { opacity: '0' },
-          '100%': { opacity: '1' },
-        },
-        fadeOut: {
-          '0%': { opacity: '1' },
-          '100%': { opacity: '0' },
-        },
-        blink: {
-          '0%, 100%': { opacity: '1' },
-          '50%': { opacity: '0' },
-        },
+      borderRadius: {
+        '4xl': '2rem',
+      },
+      boxShadow: {
+        card: '0 18px 60px rgba(0,0,0,0.28)',
+        'card-lg': '0 24px 80px rgba(0,0,0,0.36)',
       },
     },
   },
   plugins: [],
-  future: {
-    hoverOnlyWhenSupported: true,
-  },
 }


### PR DESCRIPTION
- Replace CSS with warm-dark system (--bg-0/1/2, --text-0/1/2, --line-0/1, --accent-red)
- Add direction-aware route transition animations (enter/exit forward/back)
- Replace single-page scroll app with SPA router using useState + pushState
- Add sticky desktop top nav with wordmark and active red underline
- Add mobile bottom pill nav
- Create Home: cinematic two-column layout with oversized name, profile card
- Create Work: lead + paired-row project cards with gradient banners
- Create Academic: education, experience, and skills tag cloud cards
- Create About: intro paragraphs, contact link list, highlight cards
- Update tailwind.config.js with Inter font and warm-dark color tokens

https://claude.ai/code/session_01KhcAj8dZqLzqxa4qSDb9yB