### PR TITLE
Remove Montecassino Experience section

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -17,9 +17,6 @@ export default function About() {
             <p style={{ fontSize: 16, color: 'var(--ink)', lineHeight: 1.75, marginBottom: 20 }}>
               I&apos;m a Software Engineering student at Seneca Polytechnic in Toronto, focused on building systems that extract insight from data. I enjoy working across the full stack — from designing machine learning pipelines to shipping clean web interfaces.
             </p>
-            <p style={{ fontSize: 15, color: 'var(--ink-dim)', lineHeight: 1.75, marginBottom: 20 }}>
-              Currently working as a Data Analyst at Montecassino Retirement Residence, where I automate reporting pipelines and build dashboards that support care decisions. I&apos;m actively seeking software engineering or data internship opportunities for 2026.
-            </p>
             <p style={{ fontSize: 15, color: 'var(--ink-dim)', lineHeight: 1.75, marginBottom: 36 }}>
               Outside of work and school, I contribute to open-source projects, build browser tools, and explore the intersection of language models and information integrity.
             </p>

--- a/src/pages/Work.jsx
+++ b/src/pages/Work.jsx
@@ -35,7 +35,7 @@ const GRID_PROJECTS = [
   {
     num: '05', category: 'Data',
     title: 'Reporting Pipeline Automation',
-    description: 'Reduced manual reporting work by 60% at Montecassino. Excel/Python dashboards backed by automated data refresh and validation.',
+    description: 'Reduced manual reporting work by 60% through automated pipelines. Excel/Python dashboards backed by automated data refresh and validation.',
     tags: ['Python', 'Pandas', 'Excel'],
     github: null,
     year: '2025',


### PR DESCRIPTION
Removes all traces of the Montecassino Retirement Residence experience from the website:
- Deleted the Experience card from the Academic page
- Updated the page title from "Academic & Experience" to "Academic"
- Removed the Montecassino mention from the About bio paragraph
- Rewrote the Work page project description to drop the employer name

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnFxEyxFvAGS5vQCACt5gy)_