### PR TITLE
Slow card animations, increase transparency & glass morphism, fix program label

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -148,7 +148,7 @@ a { color: inherit; text-decoration: none; }
 
 /* ── Glass card ── */
 .card, .cinema-card {
-  background: linear-gradient(180deg, rgba(255,255,255,0.022), rgba(255,255,255,0.007));
+  background: linear-gradient(180deg, rgba(255,255,255,0.09), rgba(255,255,255,0.045));
   border: 1px solid var(--line-2);
   border-radius: 16px;
   backdrop-filter: blur(28px) saturate(160%);
@@ -262,7 +262,7 @@ a { color: inherit; text-decoration: none; }
 .proj-title    { font-size: 28px; font-weight: 700; letter-spacing: -0.025em; margin: 0 0 10px; }
 .proj-title-sm { font-size: 19px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 10px; }
 .proj-body     { font-size: 14px; color: var(--ink-dim); line-height: 1.6; margin: 0; }
-.proj-mini     { transition: border-color .2s; }
+.proj-mini     { transition: transform 0.56s ease, box-shadow 0.56s ease, border-color .2s; }
 .proj-mini:hover { border-color: rgba(236,232,223,0.18); }
 
 /* ── Responsibility list ── */


### PR DESCRIPTION
## Summary
- Card hover transition slowed from 0.28s → 0.56s (2× slower), applied to all `.card` and `.cinema-card` elements
- Fixed Work page grid cards (`.card.proj-mini`) losing their hover lift — `.proj-mini` transition was overriding `.card`'s cascade; now includes `transform` and `box-shadow`
- Card background bumped to `rgba(255,255,255,0.09/0.045)` for a clearly visible frosted-glass appearance
- `backdrop-filter` blur increased 18px → 28px, saturation 130% → 160% on cards and navbar
- About page: "Software Engineering Tech" → "B.Eng in Software Engineering"

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSw1PCyo9egn942vkVM31P)_